### PR TITLE
Fix infrared capable lights not being listed when IR state request fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Visual Studio Code Local History extension
+.history

--- a/lib/lifx-light.js
+++ b/lib/lifx-light.js
@@ -36,7 +36,7 @@ function convertLifxState(lifxInfo) {
   var state = _.reduce(lifxInfo.color, (coll, value, key) => {
     if (!hueStateProperties.hasOwnProperty(key))
       return coll;
-    
+
     var stateItem = hueStateProperties[key];
 
     if (stateItem === true)
@@ -80,7 +80,7 @@ function limitValue(val, min, max) {
  */
 function LightItem(lightID, lifxLight, config) {
   EventEmitter.call(this);
-  
+
   this.initialized = false;
 
   this.id        = lightID;
@@ -151,7 +151,14 @@ LightItem.prototype.initialize = function initialize(callback) {
     (done) => {
       if (!(capability & LightCapability.INFRARED))
         return done(null, null);
-      self.lifx.getMaxIR(done);
+
+      self.lifx.getMaxIR((err, brightness) => {
+        if (err) {
+          self.emit('warn', `Could not retrieve current IR level for light ${self.lifx.id}`, err);
+          return done(null, null);
+        }
+        return done(null, brightness);
+      });
     },
 
   ], (err, data) => {
@@ -215,7 +222,13 @@ LightItem.prototype.pollChanges = function pollChanges() {
     (done) => {
       if (!(self.info.capability & LightCapability.INFRARED))
         return done(null, null);
-      self.lifx.getMaxIR(done);
+
+      self.lifx.getMaxIR((err, brightness) => {
+        if (err) {
+          return done(null, null);
+        }
+        return done(null, brightness);
+      });
     }
   ], (err, data) => {
     if (err) {
@@ -279,7 +292,7 @@ LightItem.prototype.parseColorRGB = function updateColorRGB(input, output) {
            _.isFinite(input.rgb[1]) &&
            _.isFinite(input.rgb[2])) {
     changed = true;
-    
+
     // Create new rgb ensuring values is in valid range
     let rgb = [
       limitValue(input.rgb[0], 0, 0xFF),
@@ -414,7 +427,7 @@ LightItem.prototype.parseColorTemp = function parseColorTemp(input, output) {
 LightItem.prototype.parseBrightness = function updateColorBri(input, output) {
   var bri = this.state.brightness;
   var changed = false;
-  
+
   // Brightness
   if (_.isFinite(input.bri)) {
     bri = input.bri;
@@ -617,7 +630,7 @@ LightItem.prototype.getStateMessage = function getStateMessage() {
       name:    this.info.label,
       address: this.info.address,
       model:   this.info.model,
-  
+
       // Conver bitmask to capabilities
       capability: LightCapability.enums.reduce((coll, enumItem) => {
         if (self.info.capability & enumItem)
@@ -635,7 +648,7 @@ LightItem.prototype.getStateMessage = function getStateMessage() {
 
       hsv: [ Math.round(hsv[0]), Math.round(hsv[1]), Math.round(hsv[2]) ],
       rgb: [ Math.round(rgb[0]), Math.round(rgb[1]), Math.round(rgb[2]) ],
-    
+
       hex:   colorConvert.rgb.hex(rgb),
       color: colorConvert.rgb.keyword(rgb),
 


### PR DESCRIPTION
I have nine LIFX lights of which two are IR capable. The two lights were not listed in the node editor with but they were found by node-lifx (found this out with some debug prints). The issue seems to be that `light.getMaxIR()` times out and returns an error and due to that the light never gets added on the list of lights. The pull request fixes the issue by emitting a warning once during init instead of passing the error forward with the callback. The solution is not exactly beautiful but at least allows using the lights which otherwise could not be used.

The `light.maxIR(value)` does seem to work though so I would not disable the IR capability altogether. I'm a collaborator on the node-lifx project and I believe this is an issue there rather than with this package. The `getMaxIR()` call does not return any value. I'll create an issue to node-lifx on this. My guess is that it has broken with some recent firmware update.

Unfortunately I could not think of a good way to unit test this change but the current tests pass after the change at least. If this PR is ok and you can suggest a way to test this, I can update the PR with such test.
